### PR TITLE
Make CTA button visible on mobile. Fixes #2

### DIFF
--- a/anthill/static/css/styles.css
+++ b/anthill/static/css/styles.css
@@ -87,7 +87,6 @@ body.home h1 {
 body.home .final-call {
   position: relative;
   overflow: hidden;
-  height: 40rem;
   margin-top: 5rem;
 }
 body.home .final-call .container {
@@ -95,6 +94,14 @@ body.home .final-call .container {
   width: 100%;
   height: 100%;
   z-index: 2;
+}
+
+/* add spacing after final-call container on mobile layout */
+/* width taken from skeleton.css */
+@media (max-width: 400px) {
+  body.home .final-call .container {
+    margin-bottom: 3rem;
+  }
 }
 
 


### PR DESCRIPTION
Before:

![img_0279](https://cloud.githubusercontent.com/assets/7475/17666009/760f32d6-62fe-11e6-99ee-2ab6765c50bb.jpg)

After:

![img_0281](https://cloud.githubusercontent.com/assets/7475/17665961/2f3ef044-62fe-11e6-9b60-fdb0220e0f47.jpg)

Adding the extra space after the final call container was deliberate, having it merge into the white container below looked very weird on mobile to me (unlike on desktop, it's unchanged there)

Verified on Safari, Chrome, FF Desktop
