### PR TITLE
Add og:description and og:image tags for FB. Can be overridden.

### DIFF
--- a/anthill/templates/layouts/base.html
+++ b/anthill/templates/layouts/base.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta property="og:description" content="{% block og:description %}Wenige Stunden Engagement für die Kampagne können das Wahlergebnis entscheiden.{% endblock %}" />
+    <meta property="og:image" content="{% block og:image %}{% if request.is_secure %}https://{% else %}http://{% endif %}{{ request.get_host }}/static/img/bg.jpg{% endblock %}" />
     <title>Weil's um was geht</title>
 
     {% load staticfiles %}


### PR DESCRIPTION
![2016-08-15 at 16 15](https://cloud.githubusercontent.com/assets/7475/17667076/99cc00c8-6303-11e6-86a5-b924d614680a.png)

The description and image is the same for all pages, but can be overridden using `{% block og:description %}something else{% endblock %}`.

I found stuff like https://github.com/leveille/django-opengraph, but didn't go for it since I'm not familiar with Django.
