### PR TITLE
Move background images back to CSS, but with relative paths

### DIFF
--- a/anthill/static/css/styles.css
+++ b/anthill/static/css/styles.css
@@ -177,6 +177,7 @@ body.home .photowall {
   background: #fff;
   overflow: hidden;
   list-style:none;
+  background: url(../img/cheers.jpg);
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
@@ -420,6 +421,7 @@ body.meetups .meetup_list h3 {
 }
 body.meetups .coach-photo {
   width: 100%; height: 100px;
+  background-image: url('../img/alexandra.jpg');
   background-position: 0 -20px;
   background-size: cover;
   border-top-left-radius: 2rem;
@@ -817,6 +819,7 @@ body.thankyou .final h3 {
 }
 
 body.thankyou #final-image {
+  background-image: url(../img/result.jpg);
   background-size: 190%;
   margin: 4rem auto 2rem;
 }

--- a/anthill/static/css/vdb.css
+++ b/anthill/static/css/vdb.css
@@ -176,6 +176,7 @@ body.meetups .coach.full-width-container .container {
 
 body.meetups .titlebar .coach-photo-column {
 	width: 100%;
+	background-image: url(../img/yay.jpg);
 	background-size: cover;
 	background-position: center;
 	height: 200px;

--- a/anthill/templates/layouts/base.html
+++ b/anthill/templates/layouts/base.html
@@ -17,13 +17,6 @@
     <link rel="stylesheet" href="{% static 'css/vdb.css' %}">
     <link rel="stylesheet" href="{% static 'css/fonts.css' %}">
     <link rel="stylesheet" href="{% static 'css/font-awesome.min.css' %}">
-
-    <style>
-        body.home .photowall { background: url({% static 'img/cheers.jpg' %}); }
-        body.meetups .coach-photo { background: url({% static 'img/alexandra.jpg' %}); }
-        body.thankyou #final-image { background: url({% static 'img/result.jpg' %}); }
-        body.meetups .titlebar .coach-photo-column { background: url({% static 'img/yay.jpg' %}); }
-    </style>
     {% endcompress %}
 
     <link rel="stylesheet" href="https://www.vanderbellen.at/typo3temp/compressor/merged-ca4982a3cf18f08467d5e974eb15f5ae-785d0462a774c5ac31a1082e7af0cb59.css">


### PR DESCRIPTION
Moving them to the template was just a hacky quickfix. Now that relative paths in the CSS files get rewritten, it's not needed anymore.

Fixes #119 and some other background alignment issues that were introduced by the quickfix.
